### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM golang:onbuild
+
+RUN ln -vs /go/bin/app /usr/local/bin/elastic
+
+ENTRYPOINT [ "elastic" ]


### PR DESCRIPTION
Add Dockerfile to enable image building. Useful for development and tests under Docker workflow.
Using the official Golang image, onbuild tag. More info at https://hub.docker.com/_/golang/
No Golang install needed on systems with Docker, both for running on production or for developing/testing.

Build:

```
$ docker build -t elastic-go .
```

Run:

```
$ docker run --rm -it elastic-go [options...]
```

FYI, there's a still quicker to test, already built image on my Docker Hub. Test it by running:

```
$ docker run --rm -it pataquets/elastic-go [options...]
```
Using `--rm` causes the container to be deleted after stop.