### PR TITLE
URL tracing flag

### DIFF
--- a/elastic.go
+++ b/elastic.go
@@ -391,7 +391,7 @@ func cmdStats(c *cli.Context, subCmd string) string {
 
 func httpGet(route string, trace bool) (*http.Response, error) {
 	if trace {
-		fmt.Println("GET: ", route)
+		fmt.Fprintf(os.Stderr, "GET: %s", route)
 	}
 	r, err := http.Get(route)
 


### PR DESCRIPTION
To help understand what endpoints the tool is using under the hood, use --trace to show the URLs called.